### PR TITLE
Migration to BLE Library 2.2.0-beta02 (legacy)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     // Log Bluetooth LE events in nRF Logger
     implementation 'no.nordicsemi.android:log:2.2.0'
     // BLE library
-    implementation 'no.nordicsemi.android:ble:2.1.1'
+    implementation 'no.nordicsemi.android:ble:2.2.0-beta02'
     // To add BLE Library as a module, replace the above dependency with the following
     // and uncomment 2 lines in settings.gradle file.
     // implementation project(":ble")

--- a/app/src/main/java/no/nordicsemi/android/blinky/profile/BlinkyManager.java
+++ b/app/src/main/java/no/nordicsemi/android/blinky/profile/BlinkyManager.java
@@ -34,7 +34,7 @@ import androidx.annotation.Nullable;
 
 import java.util.UUID;
 
-import no.nordicsemi.android.ble.BleManager;
+import no.nordicsemi.android.ble.LegacyBleManager;
 import no.nordicsemi.android.ble.data.Data;
 import no.nordicsemi.android.blinky.profile.callback.BlinkyButtonDataCallback;
 import no.nordicsemi.android.blinky.profile.callback.BlinkyLedDataCallback;
@@ -43,7 +43,8 @@ import no.nordicsemi.android.log.LogContract;
 import no.nordicsemi.android.log.LogSession;
 import no.nordicsemi.android.log.Logger;
 
-public class BlinkyManager extends BleManager<BlinkyManagerCallbacks> {
+@SuppressWarnings("deprecation")
+public class BlinkyManager extends LegacyBleManager<BlinkyManagerCallbacks> {
 	/** Nordic Blinky Service UUID. */
 	public final static UUID LBS_UUID_SERVICE = UUID.fromString("00001523-1212-efde-1523-785feabcd123");
 	/** BUTTON characteristic UUID. */
@@ -63,7 +64,7 @@ public class BlinkyManager extends BleManager<BlinkyManagerCallbacks> {
 	@NonNull
 	@Override
 	protected BleManagerGattCallback getGattCallback() {
-		return mGattCallback;
+		return new BlinkyBleManagerGattCallback();
 	}
 
 	/**
@@ -140,7 +141,7 @@ public class BlinkyManager extends BleManager<BlinkyManagerCallbacks> {
 	/**
 	 * BluetoothGatt callbacks object.
 	 */
-	private final BleManagerGattCallback mGattCallback = new BleManagerGattCallback() {
+	private class BlinkyBleManagerGattCallback extends BleManagerGattCallback {
 		@Override
 		protected void initialize() {
 			setNotificationCallback(mButtonCharacteristic).with(mButtonCallback);
@@ -172,7 +173,7 @@ public class BlinkyManager extends BleManager<BlinkyManagerCallbacks> {
 			mButtonCharacteristic = null;
 			mLedCharacteristic = null;
 		}
-	};
+	}
 
 	/**
 	 * Sends a request to the device to turn the LED on or off.


### PR DESCRIPTION
This PR migrates the nRF Blinky to BLE Library 2.2.0 using the `LegacyBleManager`, which is the "least effort" method. Another PR will migrate to the final solution.