### PR TITLE
Fixed issue on pre-Lollipop devices

### DIFF
--- a/app/src/main/java/no/nordicsemi/android/blinky/ScannerActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/blinky/ScannerActivity.java
@@ -66,6 +66,12 @@ public class ScannerActivity extends AppCompatActivity implements DevicesAdapter
 
     @Override
     protected void onCreate(@Nullable final Bundle savedInstanceState) {
+        // The splash screen compat library does not work for pre-Lollipop devices
+        // so for them the theme needs to be set back to AppTheme.
+        // The AppTheme.SplashScreen theme will only be used to display the loading image.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            setTheme(R.style.AppTheme);
+        }
         super.onCreate(savedInstanceState);
 
         // Set up the splash screen.

--- a/app/src/main/res/layout/activity_scanner.xml
+++ b/app/src/main/res/layout/activity_scanner.xml
@@ -26,7 +26,6 @@
 	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
-	android:background="@color/colorBackground"
 	tools:context=".ScannerActivity"
 	tools:ignore="ContentDescription">
 

--- a/app/src/main/res/layout/activity_scanner.xml
+++ b/app/src/main/res/layout/activity_scanner.xml
@@ -26,6 +26,7 @@
 	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
+	android:background="@color/colorBackground"
 	tools:context=".ScannerActivity"
 	tools:ignore="ContentDescription">
 


### PR DESCRIPTION
The latest changes with Splash screen made the Nordic logo appeared on background of the scanner activity. This PR fixes it by switching to the *AppTheme* theme for those devices when the activity is launched.