### PR TITLE
Migration from DiffUtil to ListAdapter

### DIFF
--- a/app/src/main/java/no/nordicsemi/android/blinky/adapter/DeviceDiffCallback.java
+++ b/app/src/main/java/no/nordicsemi/android/blinky/adapter/DeviceDiffCallback.java
@@ -22,38 +22,21 @@
 
 package no.nordicsemi.android.blinky.adapter;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.DiffUtil;
 
-import java.util.List;
+public class DeviceDiffCallback extends DiffUtil.ItemCallback<DiscoveredBluetoothDevice> {
 
-public class DeviceDiffCallback extends DiffUtil.Callback {
-	private final List<DiscoveredBluetoothDevice> oldList;
-	private final List<DiscoveredBluetoothDevice> newList;
-
-	DeviceDiffCallback(final List<DiscoveredBluetoothDevice> oldList,
-					   final List<DiscoveredBluetoothDevice> newList) {
-		this.oldList = oldList;
-		this.newList = newList;
+	DeviceDiffCallback() {
 	}
 
 	@Override
-	public int getOldListSize() {
-		return oldList != null ? oldList.size() : 0;
+	public boolean areItemsTheSame(@NonNull final DiscoveredBluetoothDevice oldItem, @NonNull final DiscoveredBluetoothDevice newItem) {
+		return oldItem.equals(newItem);
 	}
 
 	@Override
-	public int getNewListSize() {
-		return newList != null ? newList.size() : 0;
-	}
-
-	@Override
-	public boolean areItemsTheSame(final int oldItemPosition, final int newItemPosition) {
-		return oldList.get(oldItemPosition) == newList.get(newItemPosition);
-	}
-
-	@Override
-	public boolean areContentsTheSame(final int oldItemPosition, final int newItemPosition) {
-		final DiscoveredBluetoothDevice device = oldList.get(oldItemPosition);
-		return device.hasRssiLevelChanged();
+	public boolean areContentsTheSame(@NonNull final DiscoveredBluetoothDevice oldItem, @NonNull final DiscoveredBluetoothDevice newItem) {
+		return oldItem.hasRssiLevelChanged();
 	}
 }


### PR DESCRIPTION
This PR changes from `DiffUtil` comparison, to automatic one using [`ListAdapter`](https://developer.android.com/reference/androidx/recyclerview/widget/ListAdapter).
This removes quite a lot lines of code.