### PR TITLE
Pull to refresh

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,4 +60,7 @@ dependencies {
 
     // BLE library
     implementation 'no.nordicsemi.android:ble-livedata:2.3.1'
+
+    // Use this dependency to verify no memory leaks in the app.
+    // debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.7'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel:2.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.core:core-splashscreen:1.0.0-alpha02'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation 'androidx.activity:activity:1.4.0'
     implementation 'androidx.fragment:fragment:1.3.6'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel:2.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'

--- a/app/src/main/java/no/nordicsemi/android/blinky/ScannerActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/blinky/ScannerActivity.java
@@ -68,7 +68,7 @@ public class ScannerActivity extends AppCompatActivity implements DevicesAdapter
     protected void onCreate(@Nullable final Bundle savedInstanceState) {
         // Set the proper theme for the Activity. This could have been set in "v23/styles..xml"
         // as "postSplashScreenTheme", but as this app works on pre-API-23 devices, it needs to be
-        // set for them as well, and that code would not apply in suce case.
+        // set for them as well, and that code would not apply in such case.
         // As "postSplashScreenTheme" is optional, and setting the theme can be done using
         // setTheme, this is preferred in our case, as this also work for older platforms.
         setTheme(R.style.AppTheme);

--- a/app/src/main/java/no/nordicsemi/android/blinky/ScannerActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/blinky/ScannerActivity.java
@@ -136,6 +136,10 @@ public class ScannerActivity extends AppCompatActivity implements DevicesAdapter
                 registerForActivityResult(new ActivityResultContracts.RequestMultiplePermissions(),
                         result -> scannerViewModel.refresh()
                 );
+        binding.refreshLayout.setOnRefreshListener(() -> {
+            scannerViewModel.clear();
+            binding.refreshLayout.setRefreshing(false);
+        });
 
         // Configure views
         binding.noDevices.actionEnableLocation.setOnClickListener(v -> openLocationSettings());
@@ -170,14 +174,14 @@ public class ScannerActivity extends AppCompatActivity implements DevicesAdapter
     }
 
     @Override
-    protected void onRestart() {
-        super.onRestart();
-        clear();
+    protected void onResume() {
+        super.onResume();
+        startScan();
     }
 
     @Override
-    protected void onStop() {
-        super.onStop();
+    protected void onPause() {
+        super.onPause();
         stopScan();
     }
 
@@ -256,7 +260,8 @@ public class ScannerActivity extends AppCompatActivity implements DevicesAdapter
                     binding.stateScanning.setVisibility(View.INVISIBLE);
                     binding.noDevices.getRoot().setVisibility(View.GONE);
                     binding.noBluetoothPermission.getRoot().setVisibility(View.GONE);
-                    clear();
+
+                    scannerViewModel.clear();
                 }
             } else {
                 binding.noBluetoothPermission.getRoot().setVisibility(View.VISIBLE);
@@ -282,18 +287,17 @@ public class ScannerActivity extends AppCompatActivity implements DevicesAdapter
     }
 
     /**
+     * Starts scanning for Bluetooth LE devices.
+     */
+    private void startScan() {
+        startScan(scannerViewModel.getScannerState());
+    }
+
+    /**
      * Stops scanning for Bluetooth LE devices.
      */
     private void stopScan() {
         scannerViewModel.stopScan();
-    }
-
-    /**
-     * Clears the list of devices, which will notify the observer.
-     */
-    private void clear() {
-        scannerViewModel.getDevices().clear();
-        scannerViewModel.getScannerState().clearRecords();
     }
 
     /**

--- a/app/src/main/java/no/nordicsemi/android/blinky/viewmodels/DevicesLiveData.java
+++ b/app/src/main/java/no/nordicsemi/android/blinky/viewmodels/DevicesLiveData.java
@@ -96,7 +96,7 @@ public class DevicesLiveData extends LiveData<List<DiscoveredBluetoothDevice>> {
 	/**
 	 * Clears the list of devices.
 	 */
-	public synchronized void clear() {
+	/* package */ synchronized void clear() {
 		devices.clear();
 		filteredDevices = null;
 		postValue(null);

--- a/app/src/main/java/no/nordicsemi/android/blinky/viewmodels/ScannerStateLiveData.java
+++ b/app/src/main/java/no/nordicsemi/android/blinky/viewmodels/ScannerStateLiveData.java
@@ -118,12 +118,4 @@ public class ScannerStateLiveData extends LiveData<ScannerStateLiveData> {
 	public boolean isLocationEnabled() {
 		return locationEnabled;
 	}
-
-	/**
-	 * Notifies the observer that scanner has no records to show.
-	 */
-	public void clearRecords() {
-		hasRecords = false;
-		postValue(this);
-	}
 }

--- a/app/src/main/java/no/nordicsemi/android/blinky/viewmodels/ScannerStateLiveData.java
+++ b/app/src/main/java/no/nordicsemi/android/blinky/viewmodels/ScannerStateLiveData.java
@@ -39,7 +39,6 @@ public class ScannerStateLiveData extends LiveData<ScannerStateLiveData> {
 		this.scanningStarted = false;
 		this.bluetoothEnabled = bluetoothEnabled;
 		this.locationEnabled = locationEnabled;
-		postValue(this);
 	}
 
 	/* package */ void refresh() {
@@ -72,15 +71,30 @@ public class ScannerStateLiveData extends LiveData<ScannerStateLiveData> {
 		postValue(this);
 	}
 
+	/**
+	 * Notifies observers that a record has been found.
+	 */
 	/* package */ void recordFound() {
-		hasRecords = true;
-		postValue(this);
+		if (!hasRecords) {
+			hasRecords = true;
+			postValue(this);
+		}
+	}
+
+	/**
+	 * Notifies observers that scanner has no records to show.
+	 */
+	/* package */ void clearRecords() {
+		if (hasRecords) {
+			hasRecords = false;
+			postValue(this);
+		}
 	}
 
 	/**
 	 * Returns whether scanning is in progress.
 	 */
-	boolean isScanning() {
+	/* package */ boolean isScanning() {
 		return scanningStarted;
 	}
 

--- a/app/src/main/java/no/nordicsemi/android/blinky/viewmodels/ScannerViewModel.java
+++ b/app/src/main/java/no/nordicsemi/android/blinky/viewmodels/ScannerViewModel.java
@@ -82,11 +82,7 @@ public class ScannerViewModel extends AndroidViewModel {
 	@Override
 	protected void onCleared() {
 		super.onCleared();
-		getApplication().unregisterReceiver(bluetoothStateBroadcastReceiver);
-
-		if (Utils.isMarshmallowOrAbove()) {
-			getApplication().unregisterReceiver(locationProviderChangedReceiver);
-		}
+		unregisterBroadcastReceivers(getApplication());
 	}
 
 	public boolean isUuidFilterEnabled() {
@@ -224,10 +220,21 @@ public class ScannerViewModel extends AndroidViewModel {
 	/**
 	 * Register for required broadcast receivers.
 	 */
-	private void registerBroadcastReceivers(@NonNull final Application application) {
-		application.registerReceiver(bluetoothStateBroadcastReceiver, new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED));
+	private void registerBroadcastReceivers(@NonNull final Context context) {
+		context.registerReceiver(bluetoothStateBroadcastReceiver, new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED));
 		if (Utils.isMarshmallowOrAbove()) {
-			application.registerReceiver(locationProviderChangedReceiver, new IntentFilter(LocationManager.MODE_CHANGED_ACTION));
+			context.registerReceiver(locationProviderChangedReceiver, new IntentFilter(LocationManager.MODE_CHANGED_ACTION));
+		}
+	}
+
+	/**
+	 * Unregister all broadcast receivers.
+	 */
+	private void unregisterBroadcastReceivers(@NonNull final Context context) {
+		context.unregisterReceiver(bluetoothStateBroadcastReceiver);
+
+		if (Utils.isMarshmallowOrAbove()) {
+			context.unregisterReceiver(locationProviderChangedReceiver);
 		}
 	}
 

--- a/app/src/main/java/no/nordicsemi/android/blinky/viewmodels/ScannerViewModel.java
+++ b/app/src/main/java/no/nordicsemi/android/blinky/viewmodels/ScannerViewModel.java
@@ -31,12 +31,12 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.location.LocationManager;
 import android.preference.PreferenceManager;
-
-import androidx.annotation.NonNull;
-import androidx.lifecycle.AndroidViewModel;
+import android.util.Log;
 
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
 import no.nordicsemi.android.blinky.utils.Utils;
 import no.nordicsemi.android.support.v18.scanner.BluetoothLeScannerCompat;
 import no.nordicsemi.android.support.v18.scanner.ScanCallback;
@@ -204,8 +204,12 @@ public class ScannerViewModel extends AndroidViewModel {
 
 		@Override
 		public void onScanFailed(final int errorCode) {
-			// TODO This should be handled
-			scannerStateLiveData.scanningStopped();
+			Log.w("ScannerViewModel", "Scanning failed with code " + errorCode);
+
+			if (errorCode == ScanCallback.SCAN_FAILED_APPLICATION_REGISTRATION_FAILED) {
+				stopScan();
+				startScan();
+			}
 		}
 	};
 

--- a/app/src/main/java/no/nordicsemi/android/blinky/viewmodels/ScannerViewModel.java
+++ b/app/src/main/java/no/nordicsemi/android/blinky/viewmodels/ScannerViewModel.java
@@ -107,6 +107,14 @@ public class ScannerViewModel extends AndroidViewModel {
 	}
 
 	/**
+	 * Forgets discovered devices.
+	 */
+	public void clear() {
+		devicesLiveData.clear();
+		scannerStateLiveData.clearRecords();
+	}
+
+	/**
 	 * Updates the device filter. Devices that once passed the filter will still be shown
 	 * even if they move away from the phone, or change the advertising packet. This is to
 	 * avoid removing devices from the list.

--- a/app/src/main/res/layout/activity_scanner.xml
+++ b/app/src/main/res/layout/activity_scanner.xml
@@ -61,19 +61,25 @@
 
 	</com.google.android.material.appbar.AppBarLayout>
 
-	<androidx.recyclerview.widget.RecyclerView
-		android:id="@+id/recycler_view_ble_devices"
+	<androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+		android:id="@+id/refresh_layout"
 		android:layout_width="0dp"
 		android:layout_height="0dp"
-		android:clipToPadding="false"
-		android:paddingTop="@dimen/activity_vertical_margin_top"
-		android:paddingBottom="@dimen/activity_vertical_margin_bottom"
-		android:scrollbars="none"
 		app:layout_constraintBottom_toBottomOf="parent"
 		app:layout_constraintEnd_toEndOf="parent"
 		app:layout_constraintStart_toStartOf="parent"
-		app:layout_constraintTop_toBottomOf="@id/appbar_layout"
-		tools:listitem="@layout/device_item" />
+		app:layout_constraintTop_toBottomOf="@id/appbar_layout">
+
+		<androidx.recyclerview.widget.RecyclerView
+			android:id="@+id/recycler_view_ble_devices"
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
+			android:paddingTop="@dimen/activity_vertical_margin_top"
+			android:paddingBottom="@dimen/activity_vertical_margin_bottom"
+			android:clipToPadding="false"
+			android:scrollbars="none"
+			tools:listitem="@layout/device_item" />
+	</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
 	<!-- A view shown when there are no devices matching filter criteria -->
 	<include


### PR DESCRIPTION
This PR adds Swipe to Refresh feature on the scanner screen. Before, the list was cleared after returning from the connection screen. After the change, the user can pull the list down to clear the list.
A bug found on Samsung Folder also has been fixed, which was caused by `onScanFailed` called with `erroCode = 2`. The app assumed the scanning has stopped, and was just clearing `scanningStarted` flag, instead of restarting scanning.