### PR TITLE
Migration to BleManager 2.6

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:1.1.3")
+            from("no.nordicsemi.android.gradle:version-catalog:1.2.1")
         }
     }
 }


### PR DESCRIPTION
This PR migrates the `BlinkyManager` to new implementation of the `BleManager` from BLE Library 2.6:

1. `getGattCallback()` was removed.
2. `BlinkyManagerGattCallback` class was removed and all inner methods were moved directly to the manager without any changed.