### PR TITLE
Enabling predictive back

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:enableOnBackInvokedCallback="true"
         android:theme="@style/NordicTheme"
         tools:targetApi="33">
 

--- a/scanner/src/main/java/no/nordicsemi/android/scanner/main/DeviceListItem.kt
+++ b/scanner/src/main/java/no/nordicsemi/android/scanner/main/DeviceListItem.kt
@@ -52,7 +52,7 @@ import no.nordicsemi.android.common.ui.view.RssiIcon
 import no.nordicsemi.android.scanner.R
 
 @Composable
-internal fun DeviceListItem(
+fun DeviceListItem(
     name: String?,
     address: String,
     modifier: Modifier = Modifier,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:2.5-2")
+            from("no.nordicsemi.android.gradle:version-catalog:2.5-3")
         }
     }
 }


### PR DESCRIPTION
This PR adds Predictive Back feature for Android 15+.

Updated Nordic Gradle Plugin contains also update of Nordic Common library to version 2.2.0, which has updated `androidx.navigation:navigation` version to 2.8.4 (used to be 2.5.x).