### PR TITLE
Migration to Material 3

### DIFF
--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -16,6 +16,6 @@ dependencies {
     implementation(libs.nordic.navigation)
     implementation(libs.nordic.permissions.ble)
 
-    implementation(libs.androidx.compose.material)
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
 }

--- a/scanner/src/main/java/no/nordicsemi/android/scanner/ScannerView.kt
+++ b/scanner/src/main/java/no/nordicsemi/android/scanner/ScannerView.kt
@@ -33,7 +33,6 @@ package no.nordicsemi.android.scanner
 
 import android.os.ParcelUuid
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -45,19 +44,15 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.pullRefresh
-import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -74,7 +69,7 @@ import no.nordicsemi.android.scanner.model.DiscoveredBluetoothDevice
 import no.nordicsemi.android.scanner.repository.ScanningState
 import no.nordicsemi.android.scanner.view.internal.FilterView
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ScannerView(
     uuid: ParcelUuid?,
@@ -101,7 +96,7 @@ fun ScannerView(
             fun refresh() = scope.launch {
                 refreshing = true
                 viewModel.refresh()
-                delay(400) // TODO remove this delay and refreshing variable after updating material dependency
+                delay(400)
                 refreshing = false
             }
 
@@ -119,16 +114,11 @@ fun ScannerView(
                         .padding(horizontal = 16.dp),
                 )
 
-                val pullRefreshState  = rememberPullRefreshState(
-                    refreshing = refreshing,
+                PullToRefreshBox(
+                    isRefreshing = refreshing,
                     onRefresh = { refresh() },
-                )
-
-                Box(
                     modifier = Modifier
-                        .pullRefresh(pullRefreshState)
                         .windowInsetsPadding(insets)
-                        .clipToBounds()
                 ) {
                     DevicesListView(
                         isLocationRequiredAndDisabled = isLocationRequiredAndDisabled,
@@ -136,12 +126,6 @@ fun ScannerView(
                         modifier = Modifier.fillMaxSize(),
                         onClick = { onResult(it) },
                         deviceItem = deviceItem,
-                    )
-
-                    PullRefreshIndicator(
-                        refreshing = refreshing,
-                        state = pullRefreshState,
-                        Modifier.align(Alignment.TopCenter)
                     )
                 }
             }

--- a/scanner/src/main/java/no/nordicsemi/android/scanner/main/DevicesListView.kt
+++ b/scanner/src/main/java/no/nordicsemi/android/scanner/main/DevicesListView.kt
@@ -31,7 +31,12 @@
 
 package no.nordicsemi.android.scanner.main
 
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -53,9 +58,11 @@ internal fun DevicesListView(
         DeviceListItem(it.displayName, it.address)
     },
 ) {
+    val insets = WindowInsets.navigationBars.only(WindowInsetsSides.Bottom)
+        .union(WindowInsets(left = 8.dp, right = 8.dp, top = 16.dp, bottom = 16.dp))
     LazyColumn(
         modifier = modifier,
-        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 16.dp)
+        contentPadding = insets.asPaddingValues()
     ) {
         when (state) {
             is ScanningState.Loading -> item { ScanEmptyView(isLocationRequiredAndDisabled) }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,11 +12,10 @@ dependencyResolutionManagement {
         mavenLocal()
         google()
         mavenCentral()
-        maven(url = "https://jitpack.io")
     }
     versionCatalogs {
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:2.5-3")
+            from("no.nordicsemi.android.gradle:version-catalog:2.6.1")
         }
     }
 }


### PR DESCRIPTION
This PR fixes #92.

`material` dependency was removed in AGP 2.6.