### PR TITLE
[Bug fix] Remember back stack on rotation change (again)

### DIFF
--- a/app/src/main/java/no/nordicsemi/android/blinky/MainActivity.kt
+++ b/app/src/main/java/no/nordicsemi/android/blinky/MainActivity.kt
@@ -3,11 +3,9 @@ package no.nordicsemi.android.blinky
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
-import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import dagger.hilt.android.AndroidEntryPoint
@@ -35,7 +33,7 @@ class MainActivity: NordicActivity() {
 
 @Composable
 private fun App() {
-    val backStack = rememberSaveable { mutableStateListOf<NavKey>(ScannerKey) }
+    val backStack = rememberNavBackStack(ScannerKey)
 
     NavDisplay(
         backStack = backStack,

--- a/blinky/ui/build.gradle.kts
+++ b/blinky/ui/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     // https://github.com/NordicSemiconductor/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidFeatureConventionPlugin.kt
     alias(libs.plugins.nordic.feature)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
-    alias(libs.plugins.kotlin.parcelize) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.compose.compiler) apply false

--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     // https://github.com/NordicSemiconductor/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidFeatureConventionPlugin.kt
     alias(libs.plugins.nordic.feature)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {


### PR DESCRIPTION
This PR fixes #101 which supposedly fixed #97 but didn't. The `NavKey`s are not `Parcalable` and the app was crashing on rotation. Now it's way better.