### PR TITLE
[Bugfix] Cancelling connection when Cancel button clicked

### DIFF
--- a/blinky/ui/src/main/java/no/nordicsemi/android/blinky/ui/control/BlinkyDestination.kt
+++ b/blinky/ui/src/main/java/no/nordicsemi/android/blinky/ui/control/BlinkyDestination.kt
@@ -1,8 +1,10 @@
 package no.nordicsemi.android.blinky.ui.control
 
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
+import no.nordicsemi.android.blinky.ui.control.service.BlinkyService
 import no.nordicsemi.android.blinky.ui.control.view.BlinkyScreen
 
 @Serializable
@@ -17,8 +19,15 @@ data class BlinkyKey(val device: BlinkyDevice): NavKey
 fun EntryProviderScope<NavKey>.blinkyEntry(
     onNavigateUp: () -> Unit
 ) = entry<BlinkyKey> { key ->
+    val context = LocalContext.current
+
     BlinkyScreen(
         device = key.device,
-        onNavigateUp = onNavigateUp,
+        onNavigateUp = {
+            // Stopping the service will disconnect the devices.
+            BlinkyService.stop(context)
+
+            onNavigateUp()
+       },
     )
 }

--- a/blinky/ui/src/main/java/no/nordicsemi/android/blinky/ui/control/view/BlinkyScreen.kt
+++ b/blinky/ui/src/main/java/no/nordicsemi/android/blinky/ui/control/view/BlinkyScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -22,7 +21,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import no.nordicsemi.android.blinky.ui.R
 import no.nordicsemi.android.blinky.ui.control.BlinkyDevice
 import no.nordicsemi.android.blinky.ui.control.service.BlinkyConnectionManager
-import no.nordicsemi.android.blinky.ui.control.service.BlinkyService
 import no.nordicsemi.android.blinky.ui.control.viewmodel.BlinkyViewModel
 import no.nordicsemi.android.blinky.ui.view.DeviceConnectingView
 import no.nordicsemi.android.blinky.ui.view.DeviceDisconnectedView
@@ -41,14 +39,8 @@ internal fun BlinkyScreen(
         factory.create(device)
     }
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val context = LocalContext.current
 
-    BackHandler {
-        // Stopping the service will disconnect the devices.
-        BlinkyService.stop(context)
-
-        onNavigateUp()
-    }
+    BackHandler { onNavigateUp() }
 
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -56,12 +48,7 @@ internal fun BlinkyScreen(
     ) {
         NordicAppBar(
             title = { Text(text = viewModel.deviceName ?: stringResource(R.string.unnamed_device)) },
-            onNavigationButtonClick = {
-                // Stopping the service will disconnect the devices.
-                BlinkyService.stop(context)
-                
-                onNavigateUp()
-            },
+            onNavigationButtonClick = onNavigateUp,
             actions = {
                 LoggerAppBarIcon(onClick = viewModel::openLogger)
             }


### PR DESCRIPTION
When the app is trying to connect to an offline device, and user clicked "Cancel", the app would go out to the scanner scree, but the connection wasn't cancelled.
This is beacause the "Cancel" button was calling `onNavigateUp` directly, without `BlinkyService.stop(context)`.
The back button and <- worked.