### PR TITLE
Migration to Nordic Gradle Plugins 3.1.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,10 @@
 plugins {
-    // https://github.com/nordicsemi/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidApplicationComposeConventionPlugin.kt
-    alias(libs.plugins.nordic.application.compose)
-    // https://github.com/nordicsemi/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidHiltConventionPlugin.kt
-    alias(libs.plugins.nordic.hilt)
+    // https://github.com/nordicsemi/Nordic-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+    alias(libs.plugins.nordic.android.application)
+    // https://github.com/nordicsemi/Nordic-Gradle-Plugins/blob/main/plugins/src/main/kotlin/ComposeConventionPlugin.kt
+    alias(libs.plugins.nordic.feature.compose)
+    // https://github.com/nordicsemi/Nordic-Gradle-Plugins/blob/main/plugins/src/main/kotlin/HiltConventionPlugin.kt
+    alias(libs.plugins.nordic.feature.hilt)
 }
 
 android {
@@ -43,14 +45,22 @@ dependencies {
     // This allows to mock permission requests in mock environment.
     implementation(nordic.blek.environment.android.compose)
 
+    // Common logging facade.
+    implementation(nordic.kotlin.log)
+
     // AndroidX dependencies required by the :app module.
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.lifecycle.viewModel.navigation3)
     // Logging framework.
     implementation(libs.timber)
-    // Adds a bridge SLF4J -> Timber.
-    implementation(libs.slf4j.timber)
     // Leak Canary lib allows to easily find memory leaks in the app.
     debugImplementation(libs.leakcanary)
+
+    // Temporary fix:
+    // After updating Kotlin to 2.4.0 there's no Hilt (Dagger) version yet updated.
+    // Build fails with error:
+    // [Hilt] Provided Metadata instance has version 2.4.0, while maximum supported version is 2.3.0.
+    //        To support newer versions, update the kotlin-metadata-jvm library.
+    ksp(libs.kotlin.metadata.jvm)
 }

--- a/blinky/ble/build.gradle.kts
+++ b/blinky/ble/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    // https://github.com/nordicsemi/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
-    alias(libs.plugins.nordic.library)
-    // https://github.com/nordicsemi/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidKotlinConventionPlugin.kt
-    alias(libs.plugins.nordic.kotlin.android)
+    // https://github.com/nordicsemi/Nordic-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+    alias(libs.plugins.nordic.android.library)
+    // https://github.com/nordicsemi/Nordic-Gradle-Plugins/blob/main/plugins/src/main/kotlin/KotlinConventionPlugin.kt
+    alias(libs.plugins.nordic.kotlin)
 }
 
 android {

--- a/blinky/ble/src/main/java/no/nordicsemi/android/blinky/ble/LedButtonServiceImpl.kt
+++ b/blinky/ble/src/main/java/no/nordicsemi/android/blinky/ble/LedButtonServiceImpl.kt
@@ -146,7 +146,7 @@ internal class LedButtonServiceImpl(
                 try {
                     withTimeout(BlinkySpec.LONG_PRESS_TIMEOUT) {
                         // Await the button to be released before the timeout.
-                        button.drop(1).filter { !it }.first()
+                        button.drop(1).first { !it }
                     }
                 } catch (_: TimeoutCancellationException) {
                     // Button has not been released before the time runed out.

--- a/blinky/spec/build.gradle.kts
+++ b/blinky/spec/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    // https://github.com/nordicsemi/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
-    alias(libs.plugins.nordic.library)
-    // https://github.com/nordicsemi/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidKotlinConventionPlugin.kt
-    alias(libs.plugins.nordic.kotlin.android)
+    // https://github.com/nordicsemi/Nordic-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+    alias(libs.plugins.nordic.android.library)
+    // https://github.com/nordicsemi/Nordic-Gradle-Plugins/blob/main/plugins/src/main/kotlin/KotlinConventionPlugin.kt
+    alias(libs.plugins.nordic.kotlin)
 }
 
 android {

--- a/blinky/ui/build.gradle.kts
+++ b/blinky/ui/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
-    // https://github.com/nordicsemi/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidFeatureConventionPlugin.kt
-    alias(libs.plugins.nordic.feature)
+    // https://github.com/nordicsemi/Nordic-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+    alias(libs.plugins.nordic.android.library)
+    // https://github.com/nordicsemi/Nordic-Gradle-Plugins/blob/main/plugins/src/main/kotlin/HiltComposeConventionPlugin.kt
+    alias(libs.plugins.nordic.feature.hilt.compose)
     alias(libs.plugins.kotlin.serialization)
 }
 
@@ -21,6 +23,8 @@ dependencies {
     implementation(libs.androidx.lifecycle.service)
     // This module contains a Nav3 entry point.
     implementation(libs.androidx.navigation3.runtime)
+    // Required for BackHandler.
+    implementation(libs.androidx.activity.compose)
     // Some extra icons to make the app silky-smooth.
     implementation(libs.androidx.compose.material.icons.extended)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,11 @@
 plugins {
-    alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.serialization) apply false
-    alias(libs.plugins.hilt) apply false
-    alias(libs.plugins.ksp) apply false
-    alias(libs.plugins.compose.compiler) apply false
 
     // Nordic plugins are defined in https://github.com/nordicsemi/Nordic-Gradle-Plugins
-    alias(libs.plugins.nordic.application.compose) apply false
-    alias(libs.plugins.nordic.library) apply false
-    alias(libs.plugins.nordic.feature) apply false
-    alias(libs.plugins.nordic.kotlin.android) apply false
-    alias(libs.plugins.nordic.hilt) apply false
+    alias(libs.plugins.nordic.android.application) apply false
+    alias(libs.plugins.nordic.android.library) apply false
+    alias(libs.plugins.nordic.kotlin) apply false
+    alias(libs.plugins.nordic.feature.compose) apply false
+    alias(libs.plugins.nordic.feature.hilt) apply false
+    alias(libs.plugins.nordic.feature.hilt.compose) apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
-    // https://github.com/nordicsemi/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidFeatureConventionPlugin.kt
-    alias(libs.plugins.nordic.feature)
+    // https://github.com/nordicsemi/Nordic-Gradle-Plugins/blob/main/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+    alias(libs.plugins.nordic.android.library)
+    // https://github.com/nordicsemi/Nordic-Gradle-Plugins/blob/main/plugins/src/main/kotlin/HiltComposeConventionPlugin.kt
+    alias(libs.plugins.nordic.feature.hilt.compose)
     alias(libs.plugins.kotlin.serialization)
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         // Link: https://github.com/nordicsemi/Nordic-Gradle-Plugins
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:2.15")
+            from("no.nordicsemi.gradle:version-catalog:3.1.2")
         }
         // Link: https://github.com/nordicsemi/Nordic-Version-Catalog
         create("nordic") {


### PR DESCRIPTION
This PR migrates the app to Nordic GRadle Plugins all the way to the version [3.1.2](https://github.com/nordicsemi/Nordic-Gradle-Plugins/releases/tag/3.1.2).

This includes new plugin identifiers and behavior.
