### PR TITLE
Connecting BLEK logs with Timber

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
     implementation(nordic.blek.environment.android.compose)
 
     // Common logging facade.
-    implementation(nordic.kotlin.log)
+    implementation(nordic.kotlin.log.timber)
 
     // AndroidX dependencies required by the :app module.
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/java/no/nordicsemi/android/blinky/di/LifecycleManagement.kt
+++ b/app/src/main/java/no/nordicsemi/android/blinky/di/LifecycleManagement.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import no.nordicsemi.kotlin.ble.client.android.CentralManager
 import no.nordicsemi.kotlin.ble.core.android.AndroidEnvironment
+import no.nordicsemi.kotlin.log.Log
+import no.nordicsemi.kotlin.log.timber.Timber
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -95,6 +97,9 @@ internal class BluetoothLifecycleManager @Inject constructor(
             _environment = env
             _scope = scp
             _centralManager = centralManagerBuilder.create(env, scp)
+                .apply {
+                    logger = Log.Sink.Timber { _, _-> true}
+                }
         }
     }
 

--- a/blinky/ble/src/main/java/no/nordicsemi/android/blinky/ble/LedButtonServiceImpl.kt
+++ b/blinky/ble/src/main/java/no/nordicsemi/android/blinky/ble/LedButtonServiceImpl.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow

--- a/blinky/ui/src/main/java/no/nordicsemi/android/blinky/ui/control/service/BlinkyService.kt
+++ b/blinky/ui/src/main/java/no/nordicsemi/android/blinky/ui/control/service/BlinkyService.kt
@@ -116,6 +116,7 @@ internal class BlinkyService : LifecycleService() {
             if (connectionManager == null) {
                 // Plant a new Tree that logs to nRF Logger.
                 val tree = nRFLoggerTree(this, null, identifier, name)
+                    .apply { setLoggingTagsEnabled(false) }
                     .also { tree ->
                         Timber.plant(tree)
                         logSession.value = tree.session

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,7 @@ dependencyResolutionManagement {
         }
         // Link: https://github.com/nordicsemi/Nordic-Version-Catalog
         create("nordic") {
-            from("no.nordicsemi.android:version-catalog:2026.04.01")
+            from("no.nordicsemi.gradle:nordic-version-catalog:2026.06.00")
         }
     }
 }


### PR DESCRIPTION
This PR connects the new [log facade](https://github.com/nordicsemi/Kotlin-Util-Library/releases/tag/1.2.0) from the new version of Kotlin BLE Library ([2.0.0-beta01](https://github.com/nordicsemi/Kotlin-BLE-Library/releases/tag/2.0.0-beta01)) to Timber.