### PR TITLE
[CleanUp]`Uuid` is no longer experimental

### DIFF
--- a/app/src/mock/java/no/nordicsemi/android/blinky/di/CentralManagerBuilderModule.kt
+++ b/app/src/mock/java/no/nordicsemi/android/blinky/di/CentralManagerBuilderModule.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalUuidApi::class)
-
 package no.nordicsemi.android.blinky.di
 
 import dagger.Module

--- a/app/src/mock/java/no/nordicsemi/android/blinky/di/PeripheralSpecs.kt
+++ b/app/src/mock/java/no/nordicsemi/android/blinky/di/PeripheralSpecs.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalUuidApi::class)
-
 package no.nordicsemi.android.blinky.di
 
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/blinky/ble/src/main/java/no/nordicsemi/android/blinky/ble/BlinkyManager.kt
+++ b/blinky/ble/src/main/java/no/nordicsemi/android/blinky/ble/BlinkyManager.kt
@@ -11,7 +11,6 @@ import no.nordicsemi.kotlin.ble.client.android.CentralManager
 import no.nordicsemi.kotlin.ble.client.android.Peripheral
 import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
 import no.nordicsemi.kotlin.ble.core.ConnectionState.Disconnected.Reason
-import kotlin.uuid.ExperimentalUuidApi
 
 /**
  * A Bluetooth LE implementation of the [Blinky] interface.
@@ -23,7 +22,6 @@ import kotlin.uuid.ExperimentalUuidApi
  * @param centralManager The central manager to use to connect to the peripheral.
  * @param peripheral The peripheral.
  */
-@OptIn(ExperimentalUuidApi::class)
 class BlinkyManager(
     private val centralManager: CentralManager,
     private val peripheral: Peripheral,

--- a/blinky/ble/src/main/java/no/nordicsemi/android/blinky/ble/LedButtonProfileImpl.kt
+++ b/blinky/ble/src/main/java/no/nordicsemi/android/blinky/ble/LedButtonProfileImpl.kt
@@ -24,14 +24,12 @@ import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
 import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
 import timber.log.Timber
-import kotlin.uuid.ExperimentalUuidApi
 
 /**
  * Implementation of the [Blinky.State] interface for the LED Button Service (LBS).
  *
  * @param onReady A callback called when the profile is initialized.
  */
-@OptIn(ExperimentalUuidApi::class)
 internal class LedButtonProfileImpl(
     private val onReady: suspend CoroutineScope.(Blinky.State) -> Unit,
 ): Profile.Simple(

--- a/blinky/spec/src/main/java/no/nordicsemi/android/blinky/spec/BlinkySpec.kt
+++ b/blinky/spec/src/main/java/no/nordicsemi/android/blinky/spec/BlinkySpec.kt
@@ -1,10 +1,8 @@
 package no.nordicsemi.android.blinky.spec
 
 import kotlin.time.Duration.Companion.seconds
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalUuidApi::class)
 class BlinkySpec {
 
     companion object {

--- a/scanner/src/main/java/no/nordicsemi/android/scanner/view/BlinkyScanner.kt
+++ b/scanner/src/main/java/no/nordicsemi/android/scanner/view/BlinkyScanner.kt
@@ -10,7 +10,6 @@ import no.nordicsemi.android.common.scanner.data.OnlyWithNames
 import no.nordicsemi.android.common.scanner.data.WithServiceUuid
 import no.nordicsemi.android.common.scanner.rememberFilterState
 import no.nordicsemi.android.scanner.R
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 /**
@@ -19,7 +18,6 @@ import kotlin.uuid.Uuid
  * @param onDeviceSelected The callback that is called when a device is selected.
  * The parameters are the device identifier (MAC) and the device name (if available).
  */
-@OptIn(ExperimentalUuidApi::class)
 @Composable
 internal fun BlinkyScanner(
     onDeviceSelected: (String, String?) -> Unit,


### PR DESCRIPTION
It became stable in Kotlin 2.4.