### PR TITLE
[Bugfix] Starting foreground Service fixed

### DIFF
--- a/blinky/ui/src/main/java/no/nordicsemi/android/blinky/ui/control/service/BlinkyService.kt
+++ b/blinky/ui/src/main/java/no/nordicsemi/android/blinky/ui/control/service/BlinkyService.kt
@@ -107,10 +107,11 @@ internal class BlinkyService : LifecycleService() {
         if (identifier != null) {
             // In the Mock flavor, the actual BLUETOOTH_CONNECT permission may not be granted.
             // In that case, start the service in background.
-            if (checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
-                startForeground(NOTIFICATION_ID, createNotification(identifier, name, state.value))
-            } else {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED) {
                 updateNotification(identifier, name, state.value)
+            } else {
+                startForeground(NOTIFICATION_ID, createNotification(identifier, name, state.value))
             }
 
             if (connectionManager == null) {
@@ -310,9 +311,18 @@ internal class BlinkyService : LifecycleService() {
                     putExtra(EXTRA_NAME, device.name)
                 }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
-                context.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
-                context.startForegroundService(intent)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                // The check for BLUETOOTH_CONNECT permission is to handle the case when the
+                // app is running in mock flavor. In that case, the native BLUETOOTH_CONNECT
+                // permissions may not be granted, and starting the service with
+                // ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE type would crash the app.
+                // On native environment the permission should be granted by now by the scanner.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                    context.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED) {
+                    context.startService(intent)
+                } else {
+                    context.startForegroundService(intent)
+                }
             } else {
                 context.startService(intent)
             }

--- a/blinky/ui/src/main/java/no/nordicsemi/android/blinky/ui/control/viewmodel/BlinkyViewModel.kt
+++ b/blinky/ui/src/main/java/no/nordicsemi/android/blinky/ui/control/viewmodel/BlinkyViewModel.kt
@@ -137,7 +137,6 @@ internal class BlinkyViewModel @AssistedInject constructor(
     }
 
     override fun onCleared() {
-        super.onCleared()
         // Unbind, but keep the Service running.
         // The Service will be stopped by the BackHandler if the user navigates back to
         // the Scanner screen (see BlinkyScreen).


### PR DESCRIPTION
The `Service` should be started as a foreground service. However, when the app is started in *mock* flavor, the native `BLUETOOTH_CONNECT` permission may not be granted. When the service is then started with `FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE` type, the app crashes. For this reason, the app checks for this permission, and if denied, tries to fake it with a notification instead. This also requires a `POST_NOTIFICATIONS` permission for it to be visible, but at least the app doesn't crash.